### PR TITLE
Fixed cassette not saving

### DIFF
--- a/Source/Actors/Player.cs
+++ b/Source/Actors/Player.cs
@@ -2105,16 +2105,30 @@ public class Player : Actor, IHaveModels, IHaveSprites, IRidePlatforms, ICastPoi
 
 		if (cassette != null)
 		{
-			if (World.Entry.Submap || !Assets.Maps.ContainsKey(cassette.Map))
+			if (World.Entry.Submap) 
 			{
-				Game.Instance.Goto(new Transition()
+				Game.Instance.Goto(new Transition() 
 				{
 					Mode = Transition.Modes.Pop,
 					ToPause = true,
 					ToBlack = new SpotlightWipe(),
 					StopMusic = true
 				});
-			}
+			} 
+			//Saves and quits game if you collect a cassette without a map in a main area
+			else if (!Assets.Maps.ContainsKey(cassette.Map)) 
+			{
+				Game.Instance.Goto(new Transition() 
+				{
+					Mode = Transition.Modes.Replace,
+					Scene = () => new Overworld(true),
+					ToPause = true,
+					ToBlack = new SpotlightWipe(),
+					FromBlack = new SlideWipe(),
+					StopMusic = true,
+					Saving = true
+				});
+  			}
 			else
 			{
 				Game.Instance.Goto(new Transition()


### PR DESCRIPTION
Fixed the game not properly saving and exiting the level after collecting a cassette without a map property in a main area. 